### PR TITLE
Suggest memory usage mitigations for GTFS and card lifecycle

### DIFF
--- a/custom_components/mzkzg_transport/__init__.py
+++ b/custom_components/mzkzg_transport/__init__.py
@@ -84,7 +84,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Clean up shared caches if no more entries
         if not hass.data[DOMAIN].get("_coordinators"):
             for key in ("_plk_cache", "_plk_lock", "_ztm_fleet", "_ztm_gtfs_cache",
-                        "_ztm_gps", "_gtfsrt_cache", "_gtfsrt_vehicles", "_gtfsrt_positions",
+                        "_ztm_gps", "_gtfsrt_cache", "_gtfsrt_locks", "_gtfsrt_vehicles", "_gtfsrt_positions",
                         "_lodz_gtfs_data", "_krakow_meta", "_krakow_vehicles"):
                 hass.data[DOMAIN].pop(key, None)
     return unload_ok

--- a/custom_components/mzkzg_transport/config_flow.py
+++ b/custom_components/mzkzg_transport/config_flow.py
@@ -1260,39 +1260,50 @@ class MzkzgTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _load_gtfs_stops(self, gtfs_url: str, id_column: str = "stop_id") -> list[dict]:
         """Download a GTFS zip and parse stops.txt."""
         import csv
+        import tempfile
         import zipfile
-        from io import BytesIO, StringIO
+        from io import TextIOWrapper
+
+        max_download_bytes = 256 * 1024 * 1024
+        max_stops_bytes = 64 * 1024 * 1024
 
         try:
             _LOGGER.debug("GTFS stops: downloading %s", gtfs_url)
             session = async_get_clientsession(self.hass)
-            async with session.get(
-                gtfs_url, timeout=aiohttp.ClientTimeout(total=120)
-            ) as resp:
-                resp.raise_for_status()
-                data = await resp.read()
-            _LOGGER.debug("GTFS stops: downloaded %d bytes from %s", len(data), gtfs_url)
-        except Exception as e:
-            _LOGGER.warning("Failed to download GTFS from %s: %s", gtfs_url, e)
-            return []
+            with tempfile.SpooledTemporaryFile(max_size=8 * 1024 * 1024) as archive:
+                downloaded = 0
+                async with session.get(
+                    gtfs_url, timeout=aiohttp.ClientTimeout(total=120)
+                ) as resp:
+                    resp.raise_for_status()
+                    if resp.content_length and resp.content_length > max_download_bytes:
+                        raise ValueError("GTFS archive exceeds 256 MiB limit")
+                    async for chunk in resp.content.iter_chunked(1024 * 1024):
+                        downloaded += len(chunk)
+                        if downloaded > max_download_bytes:
+                            raise ValueError("GTFS archive exceeds 256 MiB limit")
+                        archive.write(chunk)
 
-        try:
-            stops = []
-            with zipfile.ZipFile(BytesIO(data)) as zf:
-                if "stops.txt" not in zf.namelist():
-                    return []
-                text = zf.read("stops.txt").decode("utf-8-sig")
-                reader = csv.reader(StringIO(text))
-                header = next(reader)
-                id_idx = header.index(id_column)
-                name_idx = header.index("stop_name")
-                stops_by_id = {}
-                for parts in reader:
-                    if len(parts) > max(id_idx, name_idx):
-                        sid = parts[id_idx]
-                        name = parts[name_idx]
-                        if sid and name:
-                            stops_by_id.setdefault(sid, {"id": sid, "name": name})
+                _LOGGER.debug("GTFS stops: downloaded %d bytes from %s", downloaded, gtfs_url)
+                archive.seek(0)
+                with zipfile.ZipFile(archive) as zf:
+                    if "stops.txt" not in zf.namelist():
+                        return []
+                    if zf.getinfo("stops.txt").file_size > max_stops_bytes:
+                        raise ValueError("GTFS stops.txt exceeds 64 MiB limit")
+                    with zf.open("stops.txt") as raw:
+                        with TextIOWrapper(raw, encoding="utf-8-sig", newline="") as text:
+                            reader = csv.reader(text)
+                            header = next(reader)
+                            id_idx = header.index(id_column)
+                            name_idx = header.index("stop_name")
+                            stops_by_id = {}
+                            for parts in reader:
+                                if len(parts) > max(id_idx, name_idx):
+                                    sid = parts[id_idx]
+                                    name = parts[name_idx]
+                                    if sid and name:
+                                        stops_by_id.setdefault(sid, {"id": sid, "name": name})
 
                 stops = list(stops_by_id.values())
 
@@ -1300,7 +1311,7 @@ class MzkzgTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.debug("GTFS stops: parsed %d stops from %s", len(stops), gtfs_url)
             return stops
         except Exception as e:
-            _LOGGER.warning("Failed to parse GTFS zip from %s: %s", gtfs_url, e)
+            _LOGGER.warning("Failed to load GTFS stops from %s: %s", gtfs_url, e)
             return []
 
 

--- a/custom_components/mzkzg_transport/provider_gtfsrt.py
+++ b/custom_components/mzkzg_transport/provider_gtfsrt.py
@@ -5,7 +5,7 @@ import csv
 import logging
 import zipfile
 from datetime import timedelta
-from io import BytesIO, StringIO
+from io import BytesIO, StringIO, TextIOWrapper
 
 import aiohttp
 
@@ -17,13 +17,26 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _read_csv(zf, filename):
-    """Read a GTFS CSV file from zip, return (header, rows) using proper CSV parsing."""
+    """Open a GTFS CSV file and stream its rows from the zip."""
     if filename not in zf.namelist():
-        return None, []
-    text = zf.read(filename).decode("utf-8-sig")
-    reader = csv.reader(StringIO(text))
-    header = next(reader)
-    return header, list(reader)
+        return None, iter(())
+
+    raw = zf.open(filename)
+    text = TextIOWrapper(raw, encoding="utf-8-sig", newline="")
+    reader = csv.reader(text)
+    try:
+        header = next(reader)
+    except (StopIteration, UnicodeDecodeError):
+        text.close()
+        return None, iter(())
+
+    def rows():
+        try:
+            yield from reader
+        finally:
+            text.close()
+
+    return header, rows()
 
 # GTFS-RT city configs: static GTFS zip + realtime TripUpdates URL
 GTFSRT_CITIES = {
@@ -429,7 +442,17 @@ async def fetch(coord: "MzkzgTransportCoordinator") -> dict:
     # If fewer than 5 departures, load tomorrow's schedule
     if len(unique) < 5 and gtfs.get("_raw"):
         tomorrow = now + timedelta(days=1)
-        tomorrow_deps = _get_tomorrow_departures(gtfs, coord.stop_id, tomorrow, now)
+        tomorrow_prefix = f"{tomorrow:%Y%m%d}_"
+        tomorrow_key = f"{tomorrow_prefix}{coord.stop_id}"
+        tomorrow_cache = gtfs.setdefault("_tomorrow_departures", {})
+        if tomorrow_key not in tomorrow_cache:
+            for old_key in list(tomorrow_cache):
+                if not old_key.startswith(tomorrow_prefix):
+                    tomorrow_cache.pop(old_key)
+            tomorrow_cache[tomorrow_key] = _get_tomorrow_departures(
+                gtfs, coord.stop_id, tomorrow, now
+            )
+        tomorrow_deps = tomorrow_cache[tomorrow_key]
         for d in tomorrow_deps:
             est = (d.get("estimated_time") or "")[:16]
             key = (d.get("route"), d.get("headsign"), est)
@@ -697,6 +720,15 @@ async def _get_gzm_gtfs_url(session, package_id: str, target_date=None) -> str |
 
 
 async def _get_gtfs_data(coord, session, city_cfg, now):
+    """Load GTFS data once when several stops refresh concurrently."""
+    domain_data = coord.hass.data[DOMAIN]
+    locks = domain_data.setdefault("_gtfsrt_locks", {})
+    lock = locks.setdefault(coord.provider, asyncio.Lock())
+    async with lock:
+        return await _get_gtfs_data_locked(coord, session, city_cfg, now)
+
+
+async def _get_gtfs_data_locked(coord, session, city_cfg, now):
     """Load and cache parsed GTFS data (daily)."""
     cache = coord.hass.data[DOMAIN].setdefault("_gtfsrt_cache", {})
     today = now.strftime("%Y%m%d")
@@ -879,11 +911,9 @@ def _parse_stop_times_for(gtfs, stop_id):
     trips = gtfs["trips"]
     stops = gtfs["stops"]
     with zipfile.ZipFile(BytesIO(raw)) as zf:
-        if "stop_times.txt" not in zf.namelist():
+        header, reader = _read_csv(zf, "stop_times.txt")
+        if not header:
             return
-        text = zf.read("stop_times.txt").decode("utf-8-sig")
-        reader = csv.reader(StringIO(text))
-        header = next(reader)
         tid_idx = header.index("trip_id")
         sid_idx = header.index("stop_id")
         dep_idx = header.index("departure_time")
@@ -943,11 +973,9 @@ def _parse_stop_times_from_raw(gtfs, stop_id, raw_data):
     trips = gtfs["trips"]
     stops = gtfs["stops"]
     with zipfile.ZipFile(BytesIO(raw_data)) as zf:
-        if "stop_times.txt" not in zf.namelist():
+        header, reader = _read_csv(zf, "stop_times.txt")
+        if not header:
             return
-        text = zf.read("stop_times.txt").decode("utf-8-sig")
-        reader = csv.reader(StringIO(text))
-        header = next(reader)
         tid_idx = header.index("trip_id")
         sid_idx = header.index("stop_id")
         dep_idx = header.index("departure_time")

--- a/custom_components/mzkzg_transport/sensor.py
+++ b/custom_components/mzkzg_transport/sensor.py
@@ -55,6 +55,7 @@ class MzkzgTransportSensor(CoordinatorEntity, SensorEntity):
     """Sensor representing departures from a single stop."""
 
     _attr_has_entity_name = True
+    _unrecorded_attributes = frozenset({"departures", "last_update"})
 
     def __init__(self, coordinator: MzkzgTransportCoordinator, entry: ConfigEntry) -> None:
         """Initialize the sensor."""
@@ -104,6 +105,7 @@ class MzkzgAggregatedSensor(SensorEntity):
     """Sensor that merges departures from multiple stops (węzeł przesiadkowy)."""
 
     _attr_has_entity_name = True
+    _unrecorded_attributes = frozenset({"departures", "last_update"})
 
     def __init__(self, coordinators: list, entry: ConfigEntry) -> None:
         self._coordinators = coordinators

--- a/custom_components/mzkzg_transport/www/polish-transport-card.js
+++ b/custom_components/mzkzg_transport/www/polish-transport-card.js
@@ -5,6 +5,7 @@
  */
 
 const MZKZG_VERSION = "1.5.0";
+let leafletLoadPromise = null;
 
 const LOCALE = {
   pl: {
@@ -1097,12 +1098,12 @@ class MzkzgTransportCard extends HTMLElement {
       double_tap_action: normalizeActionConfig(config.double_tap_action, "none"),
     };
     if (this._rendered) this._fullRender();
-    this._preloadLeaflet();
+    if (this.isConnected) this._startTick();
   }
 
   set hass(hass) {
     this._hass = hass;
-    if (!this._rendered) { this._fullRender(); this._startTick(); }
+    if (!this._rendered) this._fullRender();
     else {
       // Only update if our entities' states changed
       const key = this._getEntityIds().map(e => hass.states[e]?.last_updated).join(",");
@@ -1159,6 +1160,7 @@ class MzkzgTransportCard extends HTMLElement {
   disconnectedCallback() {
     if (this._tickTimer) { clearInterval(this._tickTimer); this._tickTimer = null; }
     if (this._visHandler) { document.removeEventListener("visibilitychange", this._visHandler); this._visHandler = null; }
+    if (this._mapCtx) this._mapCtx.destroy();
   }
 
   _bindVisibility() {
@@ -1289,21 +1291,39 @@ class MzkzgTransportCard extends HTMLElement {
   }
 
   _preloadLeaflet() {
-    if (!this._leafletLoading) {
-      this._leafletLoading = new Promise((resolve) => {
-        const l = document.createElement("link");
-        l.rel = "stylesheet";
-        l.href = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css";
-        l.onload = () => {
-          const s = document.createElement("script");
-          s.src = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js";
-          s.onload = resolve;
-          document.head.appendChild(s);
-        };
-        document.head.appendChild(l);
-      });
-    }
-    return this._leafletLoading;
+    if (window.L) return Promise.resolve(window.L);
+    if (leafletLoadPromise) return leafletLoadPromise;
+
+    leafletLoadPromise = new Promise((resolve, reject) => {
+      if (!document.getElementById("polish-transport-leaflet-css")) {
+        const link = document.createElement("link");
+        link.id = "polish-transport-leaflet-css";
+        link.rel = "stylesheet";
+        link.href = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css";
+        document.head.appendChild(link);
+      }
+
+      let script = document.getElementById("polish-transport-leaflet-js");
+      if (!script) {
+        script = document.createElement("script");
+        script.id = "polish-transport-leaflet-js";
+        script.src = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js";
+        document.head.appendChild(script);
+      }
+      const onLoad = () => {
+        script.removeEventListener("error", onError);
+        resolve(window.L);
+      };
+      const onError = () => {
+        script.removeEventListener("load", onLoad);
+        script.remove();
+        leafletLoadPromise = null;
+        reject(new Error("Failed to load Leaflet"));
+      };
+      script.addEventListener("load", onLoad, { once: true });
+      script.addEventListener("error", onError, { once: true });
+    });
+    return leafletLoadPromise;
   }
 
   _buildVehicleMarker(bearing, color, route, vehicleType, info, isMobile) {
@@ -1336,8 +1356,28 @@ class MzkzgTransportCard extends HTMLElement {
     const overlay = document.createElement("div");
     overlay.style.cssText = "position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);z-index:100000;display:flex;align-items:center;justify-content:center;";
     overlay.innerHTML = `<div style="position:relative;width:${w}px;height:${h}px;background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 8px 32px rgba(0,0,0,0.3);"><button style="position:absolute;top:8px;right:8px;z-index:1001;background:rgba(0,0,0,0.6);border:none;border-radius:50%;width:32px;height:32px;cursor:pointer;font-size:16px;display:flex;align-items:center;justify-content:center;color:#fff;">✕</button><div id="vmap" style="width:${w}px;height:${h}px;"></div><div id="vmap-status" style="position:absolute;bottom:6px;left:10px;z-index:1001;font-size:10px;color:#999;background:rgba(255,255,255,0.8);padding:2px 6px;border-radius:4px">🔄 odświeżanie co 30s</div></div>`;
+    const ctx = {
+      overlay,
+      map: null,
+      markers: [],
+      interval: null,
+      ro: null,
+      destroyed: false,
+      entityId: info.entityId,
+      vehicleCode: info.code,
+      destroy: () => {
+        if (ctx.destroyed) return;
+        ctx.destroyed = true;
+        if (ctx.interval) clearInterval(ctx.interval);
+        if (ctx.ro) ctx.ro.disconnect();
+        if (ctx.map) ctx.map.remove();
+        overlay.remove();
+        if (this._mapCtx === ctx) this._mapCtx = null;
+      },
+    };
+    this._mapCtx = ctx;
     document.body.appendChild(overlay);
-    const closeMap = () => { if (this._mapCtx) this._mapCtx.destroy(); };
+    const closeMap = () => ctx.destroy();
     overlay.querySelector("button").onclick = closeMap;
     overlay.onclick = (e) => { if (e.target === overlay) closeMap(); };
 
@@ -1375,7 +1415,7 @@ class MzkzgTransportCard extends HTMLElement {
     };
 
     if (window.L) { createMap(); }
-    else { (this._leafletLoading || this._preloadLeaflet()).then(createMap); }
+    else { this._preloadLeaflet().then(createMap).catch(() => ctx.destroy()); }
   }
 
   _renderAllVehicleMarkers(ctx, info, isMobile) {
@@ -1738,7 +1778,7 @@ class MzkzgTransportCard extends HTMLElement {
       if (hash !== this._lastDepsHash) {
         this._lastDepsHash = hash;
         el.innerHTML = html;
-        this._bindTapActions();
+        this._bindDepartureActions();
       }
     }
     // Re-render tabs

--- a/tests/e2e/card.spec.ts
+++ b/tests/e2e/card.spec.ts
@@ -82,6 +82,149 @@ test('opens the vehicle map for positioned departures from any provider', async 
   expect(result.openedMap).toMatchObject({ lat: 50.2649, lng: 19.0238 });
 });
 
+test('does not accumulate tab listeners during departure updates', async ({ page }) => {
+  const scriptPath = path.resolve(
+    'custom_components/mzkzg_transport/www/polish-transport-card.js'
+  );
+
+  await page.goto('about:blank');
+  await page.addScriptTag({ path: scriptPath });
+
+  const calls = await page.evaluate(() => {
+    const card = document.createElement('mzkzg-transport-card') as any;
+    card.setConfig({
+      type: 'custom:mzkzg-transport-card',
+      entities: ['sensor.first', 'sensor.second'],
+      view_mode: 'tabs',
+    });
+    let render = 0;
+    card._renderDeps = () => `<div>${render++}</div>`;
+    card.hass = {
+      states: {
+        'sensor.first': { attributes: { stop_name: 'First', departures: [] } },
+        'sensor.second': { attributes: { stop_name: 'Second', departures: [] } },
+      },
+    };
+    document.body.appendChild(card);
+
+    card._updateContent();
+    card._updateContent();
+    card._updateContent();
+
+    let clickCalls = 0;
+    card._updateContent = () => { clickCalls += 1; };
+    card.shadowRoot.querySelector('.tab[data-tab="1"]').click();
+    card.remove();
+    return clickCalls;
+  });
+
+  expect(calls).toBe(1);
+});
+
+test('shares Leaflet assets and destroys an open map on disconnect', async ({ page }) => {
+  const scriptPath = path.resolve(
+    'custom_components/mzkzg_transport/www/polish-transport-card.js'
+  );
+
+  await page.goto('about:blank');
+  await page.addScriptTag({ path: scriptPath });
+
+  const result = await page.evaluate(async () => {
+    const first = document.createElement('mzkzg-transport-card') as any;
+    const second = document.createElement('mzkzg-transport-card') as any;
+    const originalAppend = document.head.appendChild.bind(document.head);
+    document.head.appendChild = ((node: Node) => {
+      const result = originalAppend(node);
+      if ((node as HTMLElement).id === 'polish-transport-leaflet-js') {
+        queueMicrotask(() => {
+          (window as any).L = {};
+          node.dispatchEvent(new Event('load'));
+        });
+      }
+      return result;
+    }) as typeof document.head.appendChild;
+
+    const firstLoad = first._preloadLeaflet();
+    const secondLoad = second._preloadLeaflet();
+    await Promise.all([firstLoad, secondLoad]);
+    document.head.appendChild = originalAppend;
+
+    let mapRemoved = false;
+    let observerDisconnected = false;
+    const map = {
+      setView() { return this; },
+      removeLayer() {},
+      invalidateSize() {},
+      remove() { mapRemoved = true; },
+    };
+    (window as any).L = {
+      map: () => map,
+      tileLayer: () => ({ addTo() {} }),
+      circleMarker: () => ({ addTo() {} }),
+    };
+    (window as any).ResizeObserver = class {
+      observe() {}
+      disconnect() { observerDisconnected = true; }
+    };
+
+    document.body.appendChild(first);
+    first._showVehicleMap(50.0, 19.0, {
+      entityId: 'sensor.vehicle',
+      code: '42',
+      route: '7',
+    });
+    const overlay = first._mapCtx.overlay;
+    await new Promise(requestAnimationFrame);
+    first.remove();
+
+    return {
+      sharedPromise: firstLoad === secondLoad,
+      stylesheets: document.querySelectorAll('#polish-transport-leaflet-css').length,
+      scripts: document.querySelectorAll('#polish-transport-leaflet-js').length,
+      overlayRemoved: !overlay.isConnected,
+      contextCleared: first._mapCtx === null,
+      mapRemoved,
+      observerDisconnected,
+    };
+  });
+
+  expect(result).toEqual({
+    sharedPromise: true,
+    stylesheets: 1,
+    scripts: 1,
+    overlayRemoved: true,
+    contextCleared: true,
+    mapRemoved: true,
+    observerDisconnected: true,
+  });
+});
+
+test('runs the refresh timer only while connected', async ({ page }) => {
+  const scriptPath = path.resolve(
+    'custom_components/mzkzg_transport/www/polish-transport-card.js'
+  );
+
+  await page.goto('about:blank');
+  await page.addScriptTag({ path: scriptPath });
+
+  const result = await page.evaluate(() => {
+    const card = document.createElement('mzkzg-transport-card') as any;
+    card.setConfig({ type: 'custom:mzkzg-transport-card', entities: [] });
+    card.hass = { states: {} };
+    const detachedTimer = card._tickTimer;
+    document.body.appendChild(card);
+    const connectedTimer = card._tickTimer;
+    card.remove();
+    return {
+      detached: detachedTimer === null,
+      connected: connectedTimer !== null,
+      cleaned: card._tickTimer === null,
+    };
+  });
+
+  expect(result).toEqual({ detached: true, connected: true, cleaned: true });
+});
+
 test.describe('Card rendering', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(`${HA_URL}/dashboard-testing/ztm-gdansk`);

--- a/tests/test_provider_gtfsrt.py
+++ b/tests/test_provider_gtfsrt.py
@@ -14,6 +14,7 @@ from mzkzg_transport.provider_gtfsrt import (
     _parse_stop_times_for,
     _peek_zip_member,
     _get_rt_delays,
+    _read_csv,
     _parse_rt_feed,
     _parse_gtfsrt_positions,
     fetch,
@@ -59,6 +60,17 @@ def _today_str():
 
 def _day_name():
     return ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"][date.today().weekday()]
+
+
+def test_read_csv_streams_rows_from_zip():
+    """Large GTFS members are not materialized as a list or decoded string."""
+    data = _make_gtfs_zip(stops="stop_id,stop_name\nS1,First\nS2,Second")
+
+    with zipfile.ZipFile(BytesIO(data)) as zf:
+        header, rows = _read_csv(zf, "stops.txt")
+        assert header == ["stop_id", "stop_name"]
+        assert not isinstance(rows, list)
+        assert list(rows) == [["S1", "First"], ["S2", "Second"]]
 
 
 def _calendar_line(service_id, active_today=True):


### PR DESCRIPTION
> [!CAUTION]
> This PR has not been tested carefully. It should be treated as a suggested direction for investigation, not as a confirmed solution to the reported memory problems. It needs maintainer review and testing on real Home Assistant installations before release.

## Context

Related to #20 and reports of memory growth over time.

There appear to be two independent classes of memory pressure:

- The Lovelace card can retain listeners, timers, map overlays, and duplicate Leaflet assets.
- Large GTFS feeds can cause very high HA Core allocation peaks. The current Warsaw archive is about 97 MB compressed and 563 MB expanded; `stop_times.txt` alone is about 479 MB. Existing code materializes full decompressed byte/string/list representations in some paths.

## Suggested changes

- Stream GTFS CSV rows directly from ZIP members.
- Spool stop-selector downloads to temporary storage and apply defensive size limits.
- Serialize same-provider GTFS cache population to avoid duplicate concurrent parses.
- Cache tomorrow departures instead of rescanning a large feed every refresh.
- Mark bulky departure/timestamp attributes as unrecorded to reduce recorder pressure.
- Clean up card timers, tab listeners, maps, observers, and overlays.
- Share and lazily load Leaflet assets across card instances.

## Limited validation

- A standalone parse of the current Warsaw feed completed at about 257 MiB peak RSS locally. This was not run inside Home Assistant and no equivalent before/after production benchmark was performed.
- 38 focused GTFS provider tests passed using a lightweight HA utility stub because the local Python 3.14 runtime is incompatible with the repository's pinned Home Assistant 2025.1 test dependency.
- 4 focused Playwright lifecycle tests passed.
- Python/JavaScript syntax and `git diff --check` passed.
- The full test suite, long-running memory behavior, Supervisor/HAOS behavior, multiple simultaneous providers, and recorder behavior were not tested carefully.

## Risks and open questions

- Streaming changes resource lifetime and error behavior and need broader feed compatibility testing.
- Temporary-file spooling introduces disk I/O during config flow.
- The proposed 256 MiB archive and 64 MiB `stops.txt` limits may reject a legitimate future feed.
- Excluding departure attributes from recorder changes their history behavior.
- The frontend and backend changes may be better reviewed or merged separately.

This PR is intentionally presented as a suggestion rather than claiming to resolve #20 or all memory-growth reports.